### PR TITLE
Add holding info for RSE SW Bath

### DIFF
--- a/index.qmd
+++ b/index.qmd
@@ -3,7 +3,7 @@ title:  Welcome to RSE South West
 ---
 
 <!-- Add details of next meeting to meetings/next_meeting.qmd and uncomment next line -->
-<!-- {{< include meetings/next_meeting.qmd >}} -->
+{{< include meetings/next_meeting.qmd >}}
 
 
 

--- a/meetings/2026-07-31-bath/index.qmd
+++ b/meetings/2026-07-31-bath/index.qmd
@@ -1,0 +1,38 @@
+---
+title: Meeting of South West RSE's at the University of Bath
+---
+
+**When**: Friday 31st July 2026, 10am – 4:00pm (refreshments from 9:30am for a 10am start)<br>
+**Where**: Claverton Down campus (BA2 7AY)
+
+## Purpose
+
+It will be another day to showcase interesting topics, share knowledge and build networks. All are welcome, whether or not you are from the South West of the UK, and whether or not you self-define as a Research Software Engineer (RSE). [What is an RSE?](https://society-rse.org/what-is-an-rse/)
+
+## Registration and submission
+
+At the previous RSE South West events, attendees were appreciative of the variety of talks and the frequency of breaks. We will aim to repeat that and we would encourage you to contribute a talk or demo, which could be:
+
+- an **introduction to your group**
+- a **talk about a project**
+- a **showcase of a tool**
+- a **live demo** or **live coding** session
+- a poster
+- or something different
+
+We would especially encourage the submission of 5-minute lightning talks, and we will aim to include more of those in a agenda.
+
+[Register to attend and/or submit a talk](https://forms.office.com/Pages/ResponsePage.aspx?id=Ij1-N6FOLUKwrY_MiUBrnqJBc3HLK_dOiPrjjBCsFMlUNDdSRUlVTUMxVEgzVVhEUTNSS1c3Q0M5Ri4u){.btn .btn-primary}
+
+**Deadline for registering for talks: Friday 10th July 2026**  
+**Registration closes: Monday 20th July 2026**
+
+## Code of conduct
+
+All participants are expected to adhere to the [Society of RSE code of conduct for events](https://society-rse.org/about/policies/code-of-conduct/).
+
+## Acknowledgements
+
+We're grateful to the [Society of Research Software Engineering](https://society-rse.org/) for providing financial support for this meeting.
+
+![Society of RSE logo (resized), used with permission. See [https://society-rse.org/trademark-and-logo-policy/](https://society-rse.org/trademark-and-logo-policy/) for terms of use.](https://society-rse.org/wp-content/uploads/2022/05/Soc_RSE_master_logo4-766x1024.png){width=10% fig-align="left" fig-alt="The Society for Research Software Engineering logo in colour."}

--- a/meetings/index.qmd
+++ b/meetings/index.qmd
@@ -6,6 +6,10 @@ Our goal is to meet in-person a few times each year, rotating locations across t
 
 These meetings aim to complement the annual RSE conference and be useful to those in the South West / GW4 who are not part of a larger RSE group.
 
+# Upcoming meeting
+
+* [University of Bath, 31 July 2026](2026-07-31-bath/index.qmd)
+
 # Previous meetings
 
 * [University of Exeter, 20 February 2026](2026-02-20-exeter/index.qmd)

--- a/meetings/next_meeting.qmd
+++ b/meetings/next_meeting.qmd
@@ -1,3 +1,3 @@
 ::: {.callout-note title="News"}
-Next meeting: **University of Exeter** — 20 Feb 2026 · [Learn more](meetings/2026-02-20-exeter/index.qmd)
+Next meeting: **University of Bath** — Friday 31st July 2026 · [Learn more](meetings/2026-07-31-bath/index.qmd)
 :::


### PR DESCRIPTION
Adds something information about the Bath event on Friday 31st July 2026, within link to registration form and information on what types of submission are encouraged (all taken from the registration form).

@stephenpcook I'm creating a holding page for your event so people have a way of finding the registration form via the website. I'm going to self-merge the PR in the interests of getting something up there. I hope this is OK. I leave it to you to adapt as you see fit (you can take a look at the Git history of the other pages for inspiration).